### PR TITLE
add isaac requirements

### DIFF
--- a/src/isaac_sim/devcontainer-feature.json
+++ b/src/isaac_sim/devcontainer-feature.json
@@ -15,9 +15,6 @@
             "description": "Whether to install Python dependencies"
         }
     },
-    "hostRequirements": {
-        "gpu": "optional"
-    },
     "containerEnv": {
         "ISAAC_SIM_PATH": "/opt/isaac-sim",
         "DISPLAY": "${localEnv:DISPLAY}",

--- a/src/isaac_sim/devcontainer-feature.json
+++ b/src/isaac_sim/devcontainer-feature.json
@@ -15,9 +15,38 @@
             "description": "Whether to install Python dependencies"
         }
     },
-    "containerEnv": {
-        "ISAAC_SIM_PATH": "/opt/isaac-sim"
+    "hostRequirements": {
+        "gpu": "optional"
     },
+    "containerEnv": {
+        "ISAAC_SIM_PATH": "/opt/isaac-sim",
+        "DISPLAY": "${localEnv:DISPLAY}",
+        "XAUTHORITY": "${localEnv:TMPDIR:/tmp}/xauth_docker_vsc_${localWorkspaceFolderBasename}",
+        "NVIDIA_VISIBLE_DEVICES": "all",
+        "NVIDIA_DRIVER_CAPABILITIES": "all"
+    },
+    "runArgs": [
+        "--network=host",
+        "--ipc=host",
+        "--gpus=all",
+        "--device=/dev/dri:/dev/dri",
+        "--group-add=video"
+    ],
+    "mounts": [
+        "type=bind,source=/etc/localtime,target=/etc/localtime,readonly",
+        "type=bind,source=/dev/input,target=/dev/input",
+        "type=bind,source=/tmp/.X11-unix,target=/tmp/.X11-unix",
+        "type=bind,source=${localEnv:TMPDIR:/tmp}/xauth_docker_vsc_${localWorkspaceFolderBasename},target=${localEnv:TMPDIR:/tmp}/xauth_docker_vsc_${localWorkspaceFolderBasename}",
+        "type=bind,source=${localEnv:HOME}/.nvidia-omniverse/docker/cache/computecache,target=/root/.nv/ComputeCache",
+        "type=bind,source=${localEnv:HOME}/.nvidia-omniverse/docker/cache/glcache,target=/root/.cache/nvidia/GLCache",
+        "type=bind,source=${localEnv:HOME}/.nvidia-omniverse/docker/cache/kit,target=/opt/isaac-sim/cache/Kit",
+        "type=bind,source=${localEnv:HOME}/.nvidia-omniverse/docker/cache/ov,target=/root/.cache/ov",
+        "type=bind,source=${localEnv:HOME}/.nvidia-omniverse/docker/cache/pip,target=/root/.cache/pip",
+        "type=bind,source=${localEnv:HOME}/.nvidia-omniverse/docker/data,target=/root/.local/share/ov/data",
+        "type=bind,source=${localEnv:HOME}/.nvidia-omniverse/docker/documents,target=/root/Documents",
+        "type=bind,source=${localEnv:HOME}/.nvidia-omniverse/docker/logs,target=/root/.nvidia-omniverse/logs"
+    ],
+    "initializeCommand": "XAUTH=\"${localEnv:TMPDIR:/tmp}/xauth_docker_vsc_${localWorkspaceFolderBasename}\"; touch \"${XAUTH}\"; chmod a+r \"${XAUTH}\"; XAUTH_LIST=$(xauth nlist \"${localEnv:DISPLAY}\"); if [ -n \"${XAUTH_LIST}\" ]; then echo \"${XAUTH_LIST}\" | sed -e 's/^..../ffff/' | xauth -f \"${XAUTH}\" nmerge -; fi",
     "customizations": {
         "vscode": {
             "extensions": [
@@ -26,5 +55,5 @@
             ]
         }
     },
-    "postCreateCommand": "sudo chown -R ${USER}:${USER} /opt/isaac-sim"
+    "postCreateCommand": "mkdir -p ${localEnv:HOME}/.nvidia-omniverse/docker/{cache/{computecache,glcache,kit,ov,pip},data,documents,logs}"
 }

--- a/src/isaac_sim/devcontainer-feature.json
+++ b/src/isaac_sim/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "id": "isaac_sim",
     "name": "isaac_sim",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Installs NVIDIA Isaac Sim for robotics simulation",
     "options": {
         "version": {

--- a/src/isaac_sim/install.sh
+++ b/src/isaac_sim/install.sh
@@ -15,6 +15,7 @@ DOWNLOAD_URL="https://download.isaacsim.omniverse.nvidia.com/isaac-sim-standalon
 # Create installation directory
 INSTALL_DIR="/opt/isaac-sim"
 mkdir -p "${INSTALL_DIR}"
+chmod 777 /opt/isaac-sim
 
 # Use nanolayer's cache directory
 CACHE_DIR="${NANOLAYER_CACHE_DIR:-/tmp/nanolayer/cache}"
@@ -36,7 +37,7 @@ echo "Extracting Isaac Sim..."
 unzip -q -o ${CACHED_FILE} -d ${INSTALL_DIR}
 
 # Set permissions
-chown -R "${USER}:${USER}" "${INSTALL_DIR}"
+chown -R "$(id -u):$(id -g)" "${INSTALL_DIR}"
 
 # Add Isaac Sim to PATH
 echo "export ISAAC_SIM_PATH=${INSTALL_DIR}" >> ~/.bashrc
@@ -44,4 +45,6 @@ echo "export PATH=\${ISAAC_SIM_PATH}/python.sh:\$PATH" >> ~/.bashrc
 
 # Test Isaac Sim installation
 echo "Testing Isaac Sim installation..."
-${INSTALL_DIR}/python.sh -c "import omni; print('Isaac Sim installation successful!')" 
+${INSTALL_DIR}/python.sh -c "import omni; print('Isaac Sim installation successful!')"
+
+echo "Done!"


### PR DESCRIPTION
## Summary by Sourcery

This PR adds the necessary scripts to install Isaac Sim. It also configures the installation directory and sets the appropriate permissions.

Build:
- Adds a script to install Isaac Sim.
- Sets permissions for the installation directory.
- Adds Isaac Sim to the PATH.